### PR TITLE
Fixing column quotes

### DIFF
--- a/src/main/java/jfr/Analysis.java
+++ b/src/main/java/jfr/Analysis.java
@@ -111,10 +111,10 @@ public class Analysis {
     // FIXME What about heapSpace?
     void getSTWTimes() throws SQLException {
         var statement = conn.prepareStatement("""
-            SELECT "s.startTime", "s.gcId", "s.when", "s.heapUsed", "c.name", "c.duration"
+            SELECT s."startTime", s."gcId", s."when", s."heapUsed", c."name", c."duration"
             FROM "JFR"."jdk.GCHeapSummary" s, "JFR"."jdk.GarbageCollection" c
-            WHERE "s.gcId" = "c.gcId"
-            ORDER BY "s.gcId"
+            WHERE s."gcId" = c."gcId"
+            ORDER BY s."gcId"
             """);
 
         try (var rs = statement.executeQuery()) {


### PR DESCRIPTION
The quotes around column names weren't quite correct; in the original form, it was looking for a column literally named "s.gcId", whereas what you actually are after is the column "gcId" in the table aliased to s, hence "s"."gcId" or s."gcId" will work.

Note that eventually the quoting shouldn't be needed, as I'm planning to make JFR Analytics more lenient towards casing, but we're not quite there yet.